### PR TITLE
enable / disable short cut menu via configuration

### DIFF
--- a/src/Elements/Bundle/ProcessManagerBundle/Controller/IndexController.php
+++ b/src/Elements/Bundle/ProcessManagerBundle/Controller/IndexController.php
@@ -96,17 +96,20 @@ class IndexController extends AdminController
 
         $shortCutMenu = [];
 
-        $list = new Configuration\Listing();
-        $list->setUser($this->getAdminUser());
-        $list->setOrderKey('name');
-        foreach ($list->load() as $config) {
-            $group = $config->getGroup() ?: 'default';
-            $shortCutMenu[$group][] = [
-                'id' => $config->getId(),
-                'name' => $config->getName(),
-                'group' => $config->getGroup(),
-            ];
+        if($this->getParameter("elements_process_manager.shortCutMenu")) {
+            $list = new Configuration\Listing();
+            $list->setUser($this->getAdminUser());
+            $list->setOrderKey('name');
+            foreach ($list->load() as $config) {
+                $group = $config->getGroup() ?: 'default';
+                $shortCutMenu[$group][] = [
+                    'id' => $config->getId(),
+                    'name' => $config->getName(),
+                    'group' => $config->getGroup(),
+                ];
+            }
         }
+
         $data['shortCutMenu'] = $shortCutMenu ?: false;
 
         return $this->adminJson($data);

--- a/src/Elements/Bundle/ProcessManagerBundle/DependencyInjection/Configuration.php
+++ b/src/Elements/Bundle/ProcessManagerBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Elements\Bundle\ProcessManagerBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $tree = new TreeBuilder();
+        $root = $tree->root("elements_process_manager");
+
+        $root
+            ->children()
+                ->arrayNode("shortCutMenu")
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode("enabled")->isRequired()->defaultValue(true)->end()
+                    ->end()
+                ->end()
+            ->end();
+
+        return $tree;
+    }
+}

--- a/src/Elements/Bundle/ProcessManagerBundle/DependencyInjection/ElementsProcessManagerExtension.php
+++ b/src/Elements/Bundle/ProcessManagerBundle/DependencyInjection/ElementsProcessManagerExtension.php
@@ -17,20 +17,19 @@ namespace Elements\Bundle\ProcessManagerBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
-class ElementsProcessManagerExtension extends Extension
+class ElementsProcessManagerExtension extends ConfigurableExtension
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function load(array $configs, ContainerBuilder $container)
+    protected function loadInternal(array $configs, ContainerBuilder $container)
     {
         $loader = new YamlFileLoader(
             $container,
             new FileLocator(__DIR__ . '/../Resources/config')
         );
+
+        $container->setParameter("elements_process_manager.shortCutMenu", $configs["shortCutMenu"]["enabled"]);
 
         $loader->load('services.yml');
     }


### PR DESCRIPTION
This PR gives the possibility to disable / enable the short cut menu via configuration. Per default it will be enabled, as in previous versions, but can be disabled if necessary.