### PR TITLE
Update Maintenance.php

### DIFF
--- a/src/Elements/Bundle/ProcessManagerBundle/Maintenance.php
+++ b/src/Elements/Bundle/ProcessManagerBundle/Maintenance.php
@@ -134,7 +134,7 @@ class Maintenance
             $message .= ' Next execution: ' . date('Y-m-d H:i:s', $nextRunTs);
             $logger->debug($message);
             $diff = $nextRunTs - $currentTs;
-            if ($diff < 0) {
+            if ($diff <= 0) {
                 $params = [];
                 //add default callback settings if defined
                 if ($settings = $config->getExecutorSettings()) {


### PR DESCRIPTION
Fix the calculation for the execution-time.

If your Maintenance class runs on 12:00:00 and the next execution time for a script is also 12:00:00 nothing will happen.

set up cron:
`*       *      *        *       *       php bin/console process-manager:maintenance`
set up a cron script in the plugin with cronjob setting
`* * * * *`
the script is only running every second minute.