### PR TITLE
Skip not existing configured logger classes

### DIFF
--- a/src/Elements/Bundle/ProcessManagerBundle/Helper.php
+++ b/src/Elements/Bundle/ProcessManagerBundle/Helper.php
@@ -105,7 +105,11 @@ class Helper
     public static function executeMonitoringItemLoggerShutdown(MonitoringItem $monitoringItem){
         $loggers = $monitoringItem->getLoggers();
         foreach((array)$loggers as $i => $loggerConfig){
-            $logObj = new $loggerConfig['class'];
+            $loggerClass = $loggerConfig['class'];
+            if (!class_exists($loggerClass)) {
+                continue;
+            }
+            $logObj = new $loggerClass;
             if(method_exists($logObj,'handleShutdown')){
                 $result = $logObj->handleShutdown($monitoringItem,$loggerConfig);
                 if($result){


### PR DESCRIPTION
# Bugfix
If there are montitoring items which have a logger class configured which cannot be resolved (any more) the processmanger-maintenance command will fail and therefore the montioring item cleanup won't be performed. 