### PR TITLE
Fluid setters

### DIFF
--- a/src/Elements/Bundle/ProcessManagerBundle/Model/MonitoringItem.php
+++ b/src/Elements/Bundle/ProcessManagerBundle/Model/MonitoringItem.php
@@ -474,6 +474,8 @@ class MonitoringItem extends \Pimcore\Model\AbstractModel
     public function setCreationDate($creationDate)
     {
         $this->creationDate = $creationDate;
+
+        return $this;
     }
 
     /**
@@ -490,6 +492,8 @@ class MonitoringItem extends \Pimcore\Model\AbstractModel
     public function setModificationDate($modificationDate)
     {
         $this->modificationDate = $modificationDate;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
As all other setters of Elements\Bundle\ProcessManagerBundle\Model\MonitoringItem are fluid, so should setModificationDate() and setCreationDate() are. While this is not absolutely necessary for setCreationDate() because it gets called on initialisation internally, it is quite handy for setModificationDate() because this needs to be called by the called command - otherwise the `duration` field in the status table is always "-".