### PR TITLE
Fix condition, so migrations don't die

### DIFF
--- a/src/Migrations/Version00000004.php
+++ b/src/Migrations/Version00000004.php
@@ -27,7 +27,7 @@ class Version00000004 extends AbstractPimcoreMigration
             $this->addSql("ALTER TABLE " . ElementsProcessManagerBundle::TABLE_NAME_MONITORING_ITEM. " ADD COLUMN `loggers` TEXT;");
         }
 
-        if (!$monitoringTable->hasColumn('processManagerConfig')) {
+        if ($monitoringTable->hasColumn('processManagerConfig')) {
             $this->addSql("ALTER TABLE " . ElementsProcessManagerBundle::TABLE_NAME_MONITORING_ITEM . " DROP COLUMN `processManagerConfig`;");
         }
 


### PR DESCRIPTION
We shouldn't drop a column that doesn't exist. 