### PR TITLE
Check for existence of PIMCORE_CONSOLE constant

### DIFF
--- a/src/ExecutionTrait.php
+++ b/src/ExecutionTrait.php
@@ -106,7 +106,7 @@ trait ExecutionTrait
 
                 $options['monitoringItem'] = $monitoringItem;
 
-                if (!PIMCORE_CONSOLE) {
+                if (!defined('PIMCORE_CONSOLE') || !PIMCORE_CONSOLE) {
                     register_shutdown_function(function ($arguments) {
                         ElementsProcessManagerBundle::shutdownHandler($arguments);
                     }, $options);


### PR DESCRIPTION
When executing a command which uses the `ExecutionTrait` via code the constant `PIMCORE_CONSOLE` is not set. This results in `Warning: Use of undefined constant PIMCORE_CONSOLE - assumed 'PIMCORE_CONSOLE' (this will throw an Error in a future version of PHP)`