### PR TITLE
Add LogLevel options to setDefaultProcessMessage method

### DIFF
--- a/src/Model/MonitoringItem.php
+++ b/src/Model/MonitoringItem.php
@@ -615,16 +615,18 @@ class MonitoringItem extends \Pimcore\Model\AbstractModel
      * convenience function to set the process message
      *
      * @param string $itemType
+     * @param int $logLevel
      *
      * @return $this
      */
-    public function setDefaultProcessMessage($itemType = 'item')
+    public function setDefaultProcessMessage($itemType = 'item', $logLevel = Logger::NOTICE)
     {
         $currentWorkload = $this->getCurrentWorkload() ?: 1;
 
         $this->setMessage(
             'Processing '.$itemType.' '.$currentWorkload.' from '.$this->getTotalWorkload(
-            ).' ('.($this->getTotalWorkload() - $currentWorkload).' remaining)'
+            ).' ('.($this->getTotalWorkload() - $currentWorkload).' remaining)',
+            $logLevel
         );
 
         return $this;


### PR DESCRIPTION
In some cases, as there are several loggers, it could be nice to set the default message log level. It is thus possible to filter its display according to each the logger.