### PR TITLE
Use symfony standard for translations

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -34,12 +34,7 @@ class Installer extends MigrationInstaller
         $this->createTables();
         $this->copyConfig();
 
-        self::updateTranslations();
         return true;
-    }
-
-    public static function updateTranslations($replaceExistingTranslations = false){
-        Admin::importTranslationsFromFile(__DIR__ . '/Resources/translations/admin.csv',$replaceExistingTranslations);
     }
 
     public function migrateUninstall(Schema $schema, Version $version)

--- a/src/Resources/translations/admin.en.csv
+++ b/src/Resources/translations/admin.en.csv
@@ -1,4 +1,3 @@
-"key";"en"
 "plugin_pm";"Process Manager"
 "plugin_pm_processes";"Processes"
 "plugin_pm_monitoring_items";"Process Log"


### PR DESCRIPTION
Symfony looks at `<bundle dir>/Resources/translations/<domain>.<locale>.yml` by default for translations. For Pimcore backend translations the domain is `admin`. This way we do not need to import anything during installation but it just works out of the box.
And it has the additional advantage that translations fall back to `en` if no translations for desired language exist. Before this PR you only see the translation keys when you switch the account language of the current Pimcore user to anything else than `en`:
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/8749138/102457966-da09e480-4043-11eb-9de1-546593ad51ee.png)
