### PR TITLE
Remove Installer::updateTranslations() which does not exist anymore

### DIFF
--- a/src/Migrations/Version00000019.php
+++ b/src/Migrations/Version00000019.php
@@ -16,7 +16,6 @@ class Version00000019 extends AbstractPimcoreMigration
      */
     public function up(Schema $schema)
     {
-        \Elements\Bundle\ProcessManagerBundle\Installer::updateTranslations();
     }
 
     /**

--- a/src/Migrations/Version00000020.php
+++ b/src/Migrations/Version00000020.php
@@ -17,7 +17,6 @@ class Version00000020 extends AbstractPimcoreMigration
     public function up(Schema $schema)
     {
         $this->addSql("UPDATE " . ElementsProcessManagerBundle::TABLE_NAME_MONITORING_ITEM . " SET published=0 where executedByUser > 0");
-        \Elements\Bundle\ProcessManagerBundle\Installer::updateTranslations(true);
     }
 
     /**

--- a/src/Migrations/Version00000021.php
+++ b/src/Migrations/Version00000021.php
@@ -44,7 +44,6 @@ class Version00000021 extends AbstractPimcoreMigration
             ];
         }
         \Pimcore\File::putPhpFile($configFile, to_php_data_file_format($config));
-        \Elements\Bundle\ProcessManagerBundle\Installer::updateTranslations();
     }
 
     /**


### PR DESCRIPTION
Resolves #79

I did not remove `Version00000019.php` because otherwise on those systems where this translation already has been executed a message would appear stating that you have executed a migration which is not available.