### PR TITLE
Allow more than 255 steps

### DIFF
--- a/src/Migrations/Version00000022.php
+++ b/src/Migrations/Version00000022.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Elements\Bundle\ProcessManagerBundle\Migrations;
+
+use Elements\Bundle\ProcessManagerBundle\ElementsProcessManagerBundle;
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version00000022 extends AbstractPimcoreMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql(
+            'ALTER TABLE '. ElementsProcessManagerBundle::TABLE_NAME_MONITORING_ITEM.'
+            CHANGE `currentStep` `currentStep` smallint unsigned NULL,
+            CHANGE `totalSteps` `totalSteps` smallint unsigned NULL'
+        );
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->addSql(
+            'ALTER TABLE ' . ElementsProcessManagerBundle::TABLE_NAME_MONITORING_ITEM . '
+            CHANGE `currentStep` `currentStep` tinyint(3) unsigned NULL,
+            CHANGE `totalSteps` `totalSteps` tinyint(3) unsigned NULL'
+        );
+    }
+}


### PR DESCRIPTION
 Currently the columns `plugin_process_manager_monitoring_item.currentStep` and `totalSteps` are of type `unsigned tinyint` meaning that a maximum of 255 steps is supported. When you for example have a file upload you could easily excess this limit. This PR changes the column types to `unsigned smallint` allowing a maximum of 65535 steps.