### PR TITLE
Fix migrations after #78

### DIFF
--- a/src/Migrations/Version00000019.php
+++ b/src/Migrations/Version00000019.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Pimcore\Migrations\Migration\AbstractPimcoreMigration;
 
 /**
- * Auto-generated Migration: Please modify to your needs!
+ * Update translations
  */
 class Version00000019 extends AbstractPimcoreMigration
 {
@@ -16,7 +16,7 @@ class Version00000019 extends AbstractPimcoreMigration
      */
     public function up(Schema $schema)
     {
-        \Elements\Bundle\ProcessManagerBundle\Installer::updateTranslations();
+        // Removed per https://github.com/elements-at/ProcessManager/pull/78
     }
 
     /**

--- a/src/Migrations/Version00000020.php
+++ b/src/Migrations/Version00000020.php
@@ -17,7 +17,6 @@ class Version00000020 extends AbstractPimcoreMigration
     public function up(Schema $schema)
     {
         $this->addSql("UPDATE " . ElementsProcessManagerBundle::TABLE_NAME_MONITORING_ITEM . " SET published=0 where executedByUser > 0");
-        \Elements\Bundle\ProcessManagerBundle\Installer::updateTranslations(true);
     }
 
     /**

--- a/src/Migrations/Version00000021.php
+++ b/src/Migrations/Version00000021.php
@@ -44,7 +44,6 @@ class Version00000021 extends AbstractPimcoreMigration
             ];
         }
         \Pimcore\File::putPhpFile($configFile, to_php_data_file_format($config));
-        \Elements\Bundle\ProcessManagerBundle\Installer::updateTranslations();
     }
 
     /**


### PR DESCRIPTION
#78 caused migrations to break:

```
  ++ migrating 00000019
In Version00000019.php line 19:
                                                                               
  Attempted to call an undefined method named "updateTranslations" of class "  
  Elements\Bundle\ProcessManagerBundle\Installer".                             
```
