### PR TITLE
Fix metaData data type

### DIFF
--- a/src/ExecutionTrait.php
+++ b/src/ExecutionTrait.php
@@ -268,7 +268,7 @@ trait ExecutionTrait
             $monitoringItem->setCurrentWorkload($i+1)->setMessage('Processing package '. ($i+1))->save();
 
             for($x = 1; $x <= 3; $x++){
-                $result = Helper::executeJob($monitoringItem->getConfigurationId(), $monitoringItem->getCallbackSettings(), 0,$package,$monitoringItem->getId(),$callback);
+                $result = Helper::executeJob($monitoringItem->getConfigurationId(), $monitoringItem->getCallbackSettings(), 0, json_encode($package), $monitoringItem->getId(), $callback);
 
                 if($result['success'] == false){
                     $monitoringItem->getLogger()->warning("Can't start child (tried ". $i ." time ) - reason: " . $result['message']);

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -20,7 +20,7 @@ use Elements\Bundle\ProcessManagerBundle\Model\MonitoringItem;
 
 class Helper
 {
-    public static function executeJob($configId, $callbackSettings = [], $userId = 0, $metaData = [], $parentMonitoringItemId = null, $callback = '')
+    public static function executeJob($configId, $callbackSettings = [], $userId = 0, $metaData = '[]', $parentMonitoringItemId = null, $callback = '')
     {
         try {
             $config = Configuration::getById($configId);


### PR DESCRIPTION
MonitoringItem::getMetaData() is supposed to return string, but in this particular case it doesn't:

```php
$this->executeChildProcesses($parentItem, $jobs, 3, 50,
    function (MonitoringItem $childItem, PimcoreCommand $executor) use ($sourceName) {
        $metadata = $child->getMetaData();  // Should be string, but is actually array
        // ...
    }
);
```

This is a small fix for that case.