### PR TITLE
Progress bar: indicate completed child processes

### DIFF
--- a/src/ExecutionTrait.php
+++ b/src/ExecutionTrait.php
@@ -265,7 +265,7 @@ trait ExecutionTrait
                 continue;
             }
 
-            $monitoringItem->setCurrentWorkload($i+1)->setMessage('Processing package '. ($i+1))->save();
+            $monitoringItem->setCurrentWorkload($i)->setMessage('Processing package '. ($i+1))->save();
 
             for($x = 1; $x <= 3; $x++){
                 $result = Helper::executeJob($monitoringItem->getConfigurationId(), $monitoringItem->getCallbackSettings(), 0,$package,$monitoringItem->getId(),$callback);
@@ -297,6 +297,8 @@ trait ExecutionTrait
             static::childProcessCheck($monitoringItem);
             usleep(static::$childProcessCheckInterval);
         }
+
+        $monitoringItem->setCurrentWorkload($monitoringItem->getTotalWorkload())->save();
     }
 
     protected static function childProcessCheck(MonitoringItem $monitoringItem){


### PR DESCRIPTION
The progress bar currently indicates the number of *started* child processes. In the extreme case with only a single package, the progress bar will jump right to 100 % when starting.

To me, it would make more sense to have the progress bar indicate the amount of *completed* packages, not started ones, so I'm proposing that change.

I do understand that this is fundamentally a matter of opinion though, so if you rather prefer to keep it the way it is, no problem!