### PR TITLE
Fix test for failed child processes + More detailed progress for parallel imports

### DIFF
--- a/src/ExecutionTrait.php
+++ b/src/ExecutionTrait.php
@@ -287,8 +287,8 @@ trait ExecutionTrait
                 usleep(static::$childProcessCheckInterval);
             }
 
-            if($monitoringItem->getChildProcessesStatus()['failed'] ?? false){
-                throw new \Exception('Childs failed');
+            if ($monitoringItem->getChildProcessesStatus()['summary']['failed'] > 0){
+                throw new \Exception('Child process failed');
             }
         }
 
@@ -296,6 +296,10 @@ trait ExecutionTrait
             $monitoringItem->getLogger()->info('Waiting for child processes to be finished -> status: ' . print_r($monitoringItem->getChildProcessesStatus()['summary'],true));
             static::childProcessCheck($monitoringItem);
             usleep(static::$childProcessCheckInterval);
+        }
+
+        if ($monitoringItem->getChildProcessesStatus()['summary']['failed'] > 0){
+            throw new \Exception('Child process failed');
         }
     }
 

--- a/src/ExecutionTrait.php
+++ b/src/ExecutionTrait.php
@@ -251,21 +251,21 @@ trait ExecutionTrait
      * @throws \Exception
      */
     public static function executeChildProcesses(MonitoringItem $monitoringItem,array $workload, $numberOfchildProcesses = 5, $batchSize = 10, $callback = null, $startAfterPackage = null){
-        $workload = array_chunk($workload,$batchSize); //entries per process
+        $workloadChunks = array_chunk($workload,$batchSize); //entries per process
         $childProcesses = $monitoringItem->getChildProcesses();
         foreach($childProcesses as $c){
             $c->delete();
         }
         $monitoringItem->setCurrentWorkload(0)->setTotalWorkload(count($workload))->setMessage('Starting child processes')->save();
 
-        foreach($workload as $i => $package){
+        foreach($workloadChunks as $i => $package){
 
             if($startAfterPackage && $startAfterPackage > ($i+1)){
                 $monitoringItem->getLogger()->debug('Skipping Package' . ($i+1));
                 continue;
             }
 
-            $monitoringItem->setCurrentWorkload($i+1)->setMessage('Processing package '. ($i+1))->save();
+            $monitoringItem->setMessage('Processing batch '. ($i+1) . ' of ' . count($workloadChunks))->save();
 
             for($x = 1; $x <= 3; $x++){
                 $result = Helper::executeJob($monitoringItem->getConfigurationId(), $monitoringItem->getCallbackSettings(), 0,$package,$monitoringItem->getId(),$callback);
@@ -280,27 +280,9 @@ trait ExecutionTrait
                     break;
                 }
             }
-
-            while ($monitoringItem->getChildProcessesStatus()['summary']['active'] >= $numberOfchildProcesses){ //run x processes parrallel
-                $monitoringItem->getLogger()->info('Waiting to start child processes -> status: ' . print_r($monitoringItem->getChildProcessesStatus()['summary'],true));
-                static::childProcessCheck($monitoringItem);
-                usleep(static::$childProcessCheckInterval);
-            }
-
-            if ($monitoringItem->getChildProcessesStatus()['summary']['failed'] > 0){
-                throw new \Exception('Child process failed');
-            }
+            self::waitForChildProcesses($monitoringItem, $i * $batchSize, $numberOfchildProcesses);
         }
-
-        while($monitoringItem->getChildProcessesStatus()['summary']['active']){
-            $monitoringItem->getLogger()->info('Waiting for child processes to be finished -> status: ' . print_r($monitoringItem->getChildProcessesStatus()['summary'],true));
-            static::childProcessCheck($monitoringItem);
-            usleep(static::$childProcessCheckInterval);
-        }
-
-        if ($monitoringItem->getChildProcessesStatus()['summary']['failed'] > 0){
-            throw new \Exception('Child process failed');
-        }
+        self::waitForChildProcesses($monitoringItem, $i * $batchSize);
     }
 
     protected static function childProcessCheck(MonitoringItem $monitoringItem){
@@ -323,5 +305,30 @@ trait ExecutionTrait
             throw new \Exception('Exiting because child failed: ' .print_r($statuses['details'][MonitoringItem::STATUS_FAILED],true));
         }
 
+    }
+
+    /**
+     * @param MonitoringItem $monitoringItem
+     * @param int $i
+     * @param int $batchSize
+     * @param int $numberOfchildProcesses
+     * @throws \Exception
+     */
+    protected static function waitForChildProcesses(MonitoringItem $monitoringItem, int $baseline, int $maxProcesses = 0): void
+    {
+        do {
+            $status = $monitoringItem->getChildProcessesStatus();
+            $activeProcesses = $status['summary']['active'];
+
+            $monitoringItem->setCurrentWorkload($baseline + $status['currentWorkload'])->save();
+
+            $monitoringItem->getLogger()->info('Waiting to start child processes -> status: ' . print_r($status['summary'], true));
+            static::childProcessCheck($monitoringItem);
+            usleep(static::$childProcessCheckInterval);
+        } while ($activeProcesses > $maxProcesses);
+
+        if ($status['summary']['failed'] > 0) {
+            throw new \Exception('Child process failed');
+        }
     }
 }

--- a/src/Model/MonitoringItem.php
+++ b/src/Model/MonitoringItem.php
@@ -965,24 +965,30 @@ class MonitoringItem extends \Pimcore\Model\AbstractModel
     }
 
     public function getChildProcessesStatus(){
-        $result = ['active' => 0, 'failed' => 0,'finished' => 0];
-
-        $status = [];
+        $summary = ['active' => 0, 'failed' => 0,'finished' => 0];
+        $details = ['active' => [], 'failed' => [],'finished' => []];
+        $currentWorkload = 0;
 
         foreach($this->getChildProcesses() as $child){
-            $status[$child->getStatus()][] = ['id' => $child->getId(),'message' => $child->getMessage(),'alive' => $child->isAlive()];
+            $details[$child->getStatus()][] = ['id' => $child->getId(),'message' => $child->getMessage(),'alive' => $child->isAlive()];
+
+            $currentWorkload += $child->getCurrentWorkload();
 
             if($child->getStatus() == self::STATUS_FINISHED){
-                $result['finished']++;
+                $summary['finished']++;
             }else{
                 if($child->isAlive()){
-                    $result['active']++;
+                    $summary['active']++;
                 }else{
-                    $result['failed']++;
+                    $summary['failed']++;
                 }
             }
         }
 
-        return ['summary' => $result, 'details' => $status];
+        return [
+            'summary' => $summary,
+            'details' => $details,
+            'currentWorkload' => $currentWorkload,
+        ];
     }
 }


### PR DESCRIPTION
This replaces #87 and #88. It makes #87 obsolete, and integrates #88 as a separate commit (0a05b32745926c2266c6ff1a094685e292452f91) to make it easier to merge.