### PR TITLE
Fix sort for process list

### DIFF
--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -79,6 +79,12 @@ class ConfigController extends AdminController
         $list->setLimit($request->get('limit', 25));
         $list->setOffset($request->get('start'));
 
+        $sortingSettings = QueryParams::extractSortingSettings($request->request->all());
+        if ($sortingSettings['orderKey'] && $sortingSettings['order']) {
+            $list->setOrderKey($sortingSettings['orderKey']);
+            $list->setOrder($sortingSettings['order']);
+        }
+
         $list->setUser($this->getAdminUser());
 
         if ($filterCondition = QueryParams::getFilterCondition($request->get('filter'))) {


### PR DESCRIPTION
Copied code from MonitoringItemController, but I didn't do `array_merge($request->request->all(), $request->query->all())`, since it seems like parameters are always passed as POST request data.