### PR TITLE
Added return specification

### DIFF
--- a/src/ElementsProcessManagerBundle.php
+++ b/src/ElementsProcessManagerBundle.php
@@ -230,7 +230,7 @@ class ElementsProcessManagerBundle extends AbstractPimcoreBundle
         return $path;
     }
 
-    protected function getComposerPackageName()
+    protected function getComposerPackageName(): string
     {
         return 'elements/process-manager-bundle';
     }


### PR DESCRIPTION
With Pimcore versione 10.x they added this line on code 
https://github.com/pimcore/pimcore/blob/3ff186d50b7baf53ec29ebe2b516a660f6700fb2/lib/Extension/Bundle/Traits/PackageVersionTrait.php#L35
That generate an error here
https://github.com/elements-at/ProcessManager/blob/4a0715b0d9e7777a8a18345d331bc95d31276bce/src/ElementsProcessManagerBundle.php#L233

<img width="1055" alt="image" src="https://user-images.githubusercontent.com/49283657/115585094-9f52da00-a2cb-11eb-965f-5f6ff63f5941.png">

Pull request fixes that