### PR TITLE
PHP8 - Fix PHP Warning attempting to read an undefined array key.

### DIFF
--- a/src/Model/Configuration.php
+++ b/src/Model/Configuration.php
@@ -362,7 +362,8 @@ class Configuration extends \Pimcore\Model\AbstractModel
         $list = new Configuration\Listing();
         $list->setCondition($propertyName.' = ?', [$arguments[0]]);
 
-        if ($limit = $arguments[1]['limit']) {
+        $limit = $arguments[1]['limit'] ?? false;
+        if ($limit) {
             $list->setLimit($limit);
         }
         $result = $list->load();


### PR DESCRIPTION
Sorry, bad commit description, fix in PR description

With PHP8, a number of notices have been converted into warnings, like attempting to read an undefined array key.

```php
ErrorException {#2016
  #message: "Warning: Undefined array key 1"
  #code: 0
  #file: "./vendor/elements/process-manager-bundle/src/Model/Configuration.php"
  #line: 365
  #severity: E_WARNING
  trace: {
    ./vendor/elements/process-manager-bundle/src/Model/Configuration.php:365 { …}
    ./src/ExtendProcessManagerBundle/Model/Configuration.php:14 {
      App\ExtendProcessManagerBundle\Model\Configuration::createOrUpdateFromValues(array $configurationValues)
```

This PR fix it