### PR TITLE
Add Support for LazyLoad Commands

### DIFF
--- a/src/Service/CommandsValidator.php
+++ b/src/Service/CommandsValidator.php
@@ -3,6 +3,7 @@
 namespace Elements\Bundle\ProcessManagerBundle\Service;
 
 use Elements\Bundle\ProcessManagerBundle\ExecutionTrait;
+use Symfony\Component\Console\Command\LazyCommand;
 
 class CommandsValidator
 {
@@ -61,6 +62,9 @@ class CommandsValidator
 
     protected function classUsesTraits($class, $autoload = true)
     {
+        if ($class instanceof LazyCommand) {
+            $class = $class->getCommand();
+        }
         $traits = [];
 
         // Get traits of all parent classes


### PR DESCRIPTION
When using PHP8 attributes to declare a command, Symfony Command Application `registerCommands` returns `LazyCommand` class.

The `classUsesTraits` function does not detect `ExecutionTrait::class` in the command.

To reproduce
Actually, this command is avaible in process manager

```php
<?php

namespace App\Command;

use Elements\Bundle\ProcessManagerBundle\ExecutionTrait;
use Pimcore\Console\AbstractCommand;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;

class Demo extends AbstractCommand
{

    use ExecutionTrait;

    public function configure()
    {
        $this->setName('app:demo');
    }

    public function execute(InputInterface $input, OutputInterface $output)
    {
        $output->writeln('Simple Demo - Do Noting');
        return self::SUCCESS;
    }
}
```


This, not

```php
<?php

namespace App\Command;

use Elements\Bundle\ProcessManagerBundle\ExecutionTrait;
use Pimcore\Console\AbstractCommand;
use Symfony\Component\Console\Attribute\AsCommand;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;

#[AsCommand(
    name: 'app:demo',
    description: 'Demo Application'
)]
class Demo extends AbstractCommand
{

    use ExecutionTrait;
    
    public function execute(InputInterface $input, OutputInterface $output)
    {
        $output->writeln('Simple Demo - Do Noting');
        return self::SUCCESS;
    }
}

```

This PR add PHP8 attributes support.

EDIT : Add a description to PHP8 attributes, otherwise Command class is returned.