### PR TITLE
[Docs] Line break in Markdown file does not cause line break in output

### DIFF
--- a/doc/migration.md
+++ b/doc/migration.md
@@ -19,9 +19,9 @@ bin/console pimcore:bundle:update ElementsProcessManagerBundle
 
 Rename DataBase Tables 
 
-plugin_process_manager_configuration to bundle_process_manager_configuration
-plugin_process_manager_monitoring_item to bundle_process_manager_monitoring_item
-plugin_process_manager_callback_setting to bundle_process_manager_callback_setting
+* `plugin_process_manager_configuration` to `bundle_process_manager_configuration`
+* `plugin_process_manager_monitoring_item` to `bundle_process_manager_monitoring_item`
+* `plugin_process_manager_callback_setting` to `bundle_process_manager_callback_setting`
 
 Change the Version of the ProcessManger to v4.x
 ```console


### PR DESCRIPTION
Currently it gets rendered as
<img width="1105" alt="Bildschirmfoto 2022-03-03 um 14 52 51" src="https://user-images.githubusercontent.com/8749138/156578212-b0ef06fd-738a-43ba-9aff-be041fd0f4d5.png">
 