### PR TITLE
Remove forced dark background on download icon

### DIFF
--- a/src/Resources/public/css/admin.css
+++ b/src/Resources/public/css/admin.css
@@ -52,7 +52,6 @@
 
 .process_manager_icon_download {
     text-decoration: none;
-    background-color: #393c3f !important;
     width: 27px;
     border-radius: 3px;
     height: 21px;


### PR DESCRIPTION
Before:

![Screenshot 2023-05-02 at 16 21 16](https://user-images.githubusercontent.com/279826/235694835-081c6c33-a5f9-4f0e-b50e-b87d69a702c7.png)

After:

![Screenshot 2023-05-02 at 16 21 44](https://user-images.githubusercontent.com/279826/235694939-493cd501-c98e-450a-967c-c879a13e0991.png)

Before accepting/merging: Is it used anywhere else? It seemed so, but I could not find it.