### PR TITLE
Fix User Deprecated: Method "Pimcore\Model\AbstractModel::setValues()…

### DIFF
--- a/src/Model/MonitoringItem.php
+++ b/src/Model/MonitoringItem.php
@@ -339,6 +339,9 @@ class MonitoringItem extends \Pimcore\Model\AbstractModel
         return $self->getDao()->getById($id);
     }
 
+    /**
+     * @return static
+     */
     public function setValues($data = [])
     {
         if (is_array($data) && count($data) > 0) {


### PR DESCRIPTION
…" might add "static" as a native return type

Silences/fixes this:

> [php] User Deprecated: Method "Pimcore\Model\AbstractModel::setValues()" might add "static" as a native return type declaration in the future. Do the same in child class "Elements\Bundle\ProcessManagerBundle\Model\MonitoringItem" now to avoid errors or add an explicit @return annotation to suppress this message. ["exception" => ErrorException { …}]
