### PR TITLE
Documentation update (link correction, feature description)

### DIFF
--- a/doc/actions.md
+++ b/doc/actions.md
@@ -39,7 +39,8 @@ $monitoringItem->save();
 
 ## Action Types:
 ### Download
-Provides a download button after the process has been finished. 
+Provides a download button after the process has been finished successfully. 
+
 Programmatically creation: 
 
 ```php
@@ -56,8 +57,19 @@ $monitoringItem->setActions([
 $monitoringItem->save();
 ```
 
+There is an optional property ```ExecuteAtStates``` available to define also other states than ```finished``` for providing the download button:
+
+```php
+$downloadAction
+    ->setExecuteAtStates(['finished','finished_with_errors'])
+    ->setAccessKey('myIcon')
+    ->setLabel('Download Icon')
+    ->setFilePath('/public/bundles/elementsprocessmanager/img/sprite-open-item-action.png')
+    ->setDeleteWithMonitoringItem(false);
+```
+
 ### Open Item
-The "Open item" shows a button after the process is finished with which the user can open an object/document/asset. 
+The "Open item" shows a button after the process is finished successfully with which the user can open an object/document/asset. 
 
 Programmatically creation: 
 
@@ -74,6 +86,9 @@ $monitoringItem->setActions([
 
 $monitoringItem->save();
 ```
+
+Also the Open Item action supports the optional property ```ExecuteAtStates``` as described above.
+
 ### JS Event
 The JS Event fires a custom javascript event. In your Bundle you can perform custom actions... 
 Lets assume you add an event with the event name "export.sayHello".

--- a/doc/usageParallelization.md
+++ b/doc/usageParallelization.md
@@ -1,7 +1,7 @@
 ### How to use - Parallelization / Multiprocessing
 
 The Processmanager allows you to execute multiple child processes. Before you use the multiprocessing option please make sure
-that you have read the [Basic usage guide](/doc/usage.md).
+that you have read the [Basic usage guide](/doc/gettingStarted.md).
 
 To get started please take a look at the [Sample Command](sample/src/App/Command/MultiprocessingSampleCommand.php) which shows how to use the feature.
 


### PR DESCRIPTION
I found a broken link in the parallelization documentation and fixed that one. In addition I also added a hint in the Actions document to describe the optional property ExecuteAtStates