### PR TITLE
Remove json encode for child process metadata

### DIFF
--- a/src/Controller/CallbackSettingsController.php
+++ b/src/Controller/CallbackSettingsController.php
@@ -87,7 +87,7 @@ class CallbackSettingsController extends UserAwareController
         $list->setOrder('DESC');
         $list->setOrderKey('id');
         $list->setLimit($request->get('limit', 25));
-        $list->setOffset($request->get('start'));
+        $list->setOffset($request->get('start', 0));
         if ($filterCondition = QueryParams::getFilterCondition((string)$request->get('filter'))) {
             $list->setCondition($filterCondition);
         }

--- a/src/ExecutionTrait.php
+++ b/src/ExecutionTrait.php
@@ -285,7 +285,7 @@ trait ExecutionTrait
             $monitoringItem->setMessage('Processing batch '. ($i + 1) . ' of ' . count($workloadChunks))->save();
 
             for($x = 1; $x <= 3; $x++) {
-                $result = Helper::executeJob($monitoringItem->getConfigurationId(), $monitoringItem->getCallbackSettings(), 0, json_encode($package, JSON_THROW_ON_ERROR), $monitoringItem->getId(), $callback);
+                $result = Helper::executeJob($monitoringItem->getConfigurationId(), $monitoringItem->getCallbackSettings(), 0, $package, $monitoringItem->getId(), $callback);
 
                 if($result['success'] == false) {
                     $attempts = $i === 1 ? "$i time" : "$i times";

--- a/src/Resources/public/css/admin.css
+++ b/src/Resources/public/css/admin.css
@@ -33,12 +33,12 @@
     font-weight: bold;
 }
 
-/*.plugin-process-manager-status-finished,*/
+.plugin-process-manager-status-finished,
 .process-manager-notification-progress-bar.finished,
 .process-manager-notification-progress-bar.finished .x-progress-bar {
     background-color: #9ACD32;
 }
-/*.plugin-process-manager-status-failed,*/
+.plugin-process-manager-status-failed,
 .process-manager-notification-progress-bar.finished_with_errors ,
 .process-manager-notification-progress-bar.finished_with_errors .x-progress-bar ,
 .process-manager-notification-progress-bar.failed,


### PR DESCRIPTION
- Removes use of `json_encode` when executing child processes to match `setMetadata` function parameter type
- Fixes bug where an exception was thrown when loading a predefined config, which meant the predefined config could not be loaded at all
- Adds background colours back to process list