### PR TITLE
Add void return-type to MigrationGeneratorCommand::configure()

### DIFF
--- a/src/Command/MigrationGeneratorCommand.php
+++ b/src/Command/MigrationGeneratorCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class MigrationGeneratorCommand extends AbstractCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('process-manager:migrations:generate')


### PR DESCRIPTION
Fixes deprecation warning:

*Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "Elements\Bundle\ProcessManagerBundle\Command\MigrationGeneratorCommand" now to avoid errors or add an explicit @return annotation to suppress this message.*