### PR TITLE
Add PHP 8.3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "pimcore-bundle",
   "description": "The Process Manager allows you to manage (define,execute...) arbitrary processes/commands in the Pimcore backend.",
   "require": {
-    "php": "~8.1.0 || ~8.2.0",
+    "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
     "pimcore/pimcore": "^11.0",
     "dragonmantank/cron-expression": "^v3.1.0"
   },


### PR DESCRIPTION
Resolves #208 

## Fully tested flows
1. Config
2. Process Log
3. Crontab excecution
4. Adding custom action button via JS Event
5. Email Logger

## PHP 8.3 Incompatible changes
https://www.php.net/manual/en/migration83.incompatible.php
> #### Uses of traits with static properties
> Uses of traits with static properties will now redeclare static properties inherited from the parent class. This will create a separate static property storage for the current class. This is analogous to adding the static property to the class directly without traits.

`ExecutionTrait` has some static properties, they are only accessed via `static::$propName` calls so this shouldn't have any notable change.

> The DateTime extension has introduced Date extension specific exceptions and errors under the [DateError](https://www.php.net/manual/en/class.dateerror.php) and [DateException](https://www.php.net/manual/en/class.dateexception.php) hierarchies, instead of warnings and generic exceptions. This improves error handling, at the expense of having to check for errors and exceptions.

The only `DateTime` usage is in `Model\Configuration::getNextCronJobExecutionTimestamp()` where we rely on a correctly parsed date already so we can't expect an exception here.

All the other notes are note applicable

Ps. this is a somewhat older commit, I just needed some time to update the rest of our application before I got to the point that I could really test Process Manager :)

