### PR TITLE
Use setOrderKey instead of setOrder

### DIFF
--- a/src/Model/MonitoringItem.php
+++ b/src/Model/MonitoringItem.php
@@ -777,7 +777,7 @@ class MonitoringItem extends \Pimcore\Model\AbstractModel
     {
         $list = new MonitoringItem\Listing();
         $list->setCondition('parentId = ?', [$this->getId()]);
-        $list->setOrder('id');
+        $list->setOrderKey('id');
 
         return $list->load();
     }


### PR DESCRIPTION
Fixes failing child processes due to [this change](https://github.com/pimcore/pimcore/pull/16742) in the pimcore repository