### PR TITLE
Update MonitoringItem to make sure to send strings where required

### DIFF
--- a/src/Model/MonitoringItem.php
+++ b/src/Model/MonitoringItem.php
@@ -281,7 +281,7 @@ class MonitoringItem extends \Pimcore\Model\AbstractModel
                 if (in_array($key, ['callbackSettings', 'actions', 'loggers','metaData']) && is_string($value)) {
                     $value = json_decode($value, true);
                 }
-                if ($key == 'message') {
+                if ($key == 'message' && is_string($value)) {
                     $this->setMessage($value, false);
                 } else {
                     $this->setValue($key, $value);


### PR DESCRIPTION
Fixes error:
```
In MonitoringItem.php line 398:
Elements\Bundle\ProcessManagerBundle\Model\MonitoringItem::setMessage(): Argument #1 ($message) must be of type string, null given, called in /var/www/pimcore/vendor/elements/process-manager-bundle/src/Model/MonitoringItem.php on line 285
```