### PR TITLE
fixed deprecation nullable for callback param in ExecutionTrait

### DIFF
--- a/src/ExecutionTrait.php
+++ b/src/ExecutionTrait.php
@@ -263,7 +263,7 @@ trait ExecutionTrait
      *
      * @throws \Exception
      */
-    public static function executeChildProcesses(MonitoringItem $monitoringItem, array $workload, int $numberOfchildProcesses = 5, int $batchSize = 10, callable $callback = null, $startAfterPackage = null): void
+    public static function executeChildProcesses(MonitoringItem $monitoringItem, array $workload, int $numberOfchildProcesses = 5, int $batchSize = 10, ?callable $callback = null, $startAfterPackage = null): void
     {
         $workloadChunks = array_chunk($workload, $batchSize); //entries per process
         $childProcesses = $monitoringItem->getChildProcesses();


### PR DESCRIPTION
Pimcore 12.3.11 and PHP 8.4.17 fetched deprecation info:

`[2026-07-15T01:26:02.068420+02:00] http://php.INFO : Deprecated: Elements\Bundle\ProcessManagerBundle\ExecutionTrait::executeChildProcesses(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead {"exception":"[object] (ErrorException(code: 0): Deprecated: Elements\\Bundle\\ProcessManagerBundle\\ExecutionTrait::executeChildProcesses(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead at /var/www/pimcore.xxx.dev/www/vendor/elements/process-manager-bundle/src/ExecutionTrait.php:266)"} []`

Fixed by type hinting as null is required for default value.