### PR TITLE
fix(logger): accept any Monolog handler as process manager log writer

### DIFF
--- a/src/Executor/Logger/AbstractLogger.php
+++ b/src/Executor/Logger/AbstractLogger.php
@@ -8,8 +8,7 @@
 namespace Elements\Bundle\ProcessManagerBundle\Executor\Logger;
 
 use Elements\Bundle\ProcessManagerBundle\Model\MonitoringItem;
-use Monolog\Handler\StreamHandler;
-use Pimcore\Bundle\ApplicationLoggerBundle\Handler\ApplicationLoggerDb;
+use Monolog\Handler\HandlerInterface;
 
 abstract class AbstractLogger
 {
@@ -93,9 +92,16 @@ abstract class AbstractLogger
     abstract public function getGridLoggerHtml(MonitoringItem $monitoringItem, array $actionData): string;
 
     /**
+     * Returns the log writer which is registered on the monitoring item logger.
+     *
+     * Any Monolog handler is accepted here, because the return value is passed to
+     * ApplicationLogger::addWriter(), which handles every HandlerInterface implementation.
+     * Restricting this to StreamHandler would rule out handlers that do not write to a
+     * stream, for example the AsyncAws CloudWatch handler.
+     *
      * @param array<mixed> $config
      * @param MonitoringItem $monitoringItem
      *
      */
-    abstract public function createStreamHandler(array $config, MonitoringItem $monitoringItem): StreamHandler | ApplicationLoggerDb | null;
+    abstract public function createStreamHandler(array $config, MonitoringItem $monitoringItem): ?HandlerInterface;
 }


### PR DESCRIPTION
## Problem

`AbstractLogger::createStreamHandler()` is typed `StreamHandler | ApplicationLoggerDb | null`, but its only consumer is `MonitoringItem::getLogger()`:

```php
$streamHandler = $obj->createStreamHandler($loggerConfig, $this);
if ($streamHandler) {
    $this->logger->addWriter($streamHandler);
}
```

`ApplicationLogger::addWriter(object $writer)` accepts every `HandlerInterface` implementation. The declared union is therefore narrower than what the bundle actually supports, and it rules out every Monolog handler that does not happen to extend `StreamHandler`: the AsyncAws CloudWatch handler, Sentry, Slack, Redis, and so on.

That `ApplicationLoggerDb` is already part of the union, and is not a `StreamHandler`, shows the intent was "a log writer", not "a stream".

A project cannot work around this. The return type of an overriding method may only be narrowed, never widened, so returning a non-stream handler is impossible. In our case the custom CloudWatch logger had to return `null` to satisfy the signature, which silently disabled process manager logging to CloudWatch: `getLogger()` drops a `null` writer without a warning.

## Change

Widen the abstract return type to `?HandlerInterface`, drop the two imports that become unused.

Backwards compatible. All four shipped implementations keep their current, narrower return types, which covariance allows:

- `File` — `?StreamHandler`
- `Console` — `?StreamHandler`
- `EmailSummary` — `?StreamHandler`
- `Application` — `ApplicationLoggerDb`

Project implementations that already return one of those types are unaffected.

The method name stays `createStreamHandler()` to avoid a breaking rename.

## Branches

The same commit is proposed for `pimcore11` in #238, the file is identical on both branches.
